### PR TITLE
Enable dm_multipath and dm_round_robin kernel modules in preparation …

### DIFF
--- a/instances/standard.nix
+++ b/instances/standard.nix
@@ -1,4 +1,6 @@
 {
+  boot.kernelModules = [ "dm_multipath" "dm_round_robin" ];
+
   services = {
     openssh = {
       enable = true;


### PR DESCRIPTION
…for block storage support.