### PR TITLE
Lint and fmt of python files

### DIFF
--- a/install-tools/bin/notify.py
+++ b/install-tools/bin/notify.py
@@ -6,33 +6,25 @@ import requests
 import os
 import sys
 
+
 def cb_partitioned(url, instance_id):
-    requests.put(
-        url,
-        json={
-            "type": "provisioning.105",
-            "body": "Server partitions created"
-            }
-        )
+    requests.put(url, json={"type": "provisioning.105", "body": "Server partitions created"})
     print("Announced partitions")
+
 
 def cb_installed(url, instance_id):
     requests.put(
-        url,
-        json={
+        url, json={
             "type": "provisioning.109",
             "body": "Installation finished, rebooting server"
-            }
-        )
+        })
     print("Announced installed")
 
+
 def cb_booted(url, instance_id):
-    print(
-        "curl -H 'Content-Type: application/json' -d'{}' {}".format(
-            '{{"instance_id": "{}"}}'.format(instance_id),
-            url
-            )
-        )
+    print("curl -H 'Content-Type: application/json' -d'{}' {}".format(
+        '{{"instance_id": "{}"}}'.format(instance_id), url))
+
 
 cbs = {
     "partitioned": cb_partitioned,
@@ -52,7 +44,6 @@ while True:
         break
     except:
         pass
-
 
 url = d['phone_home_url']
 instance_id = d['id']

--- a/install-tools/metadata2hardware.py
+++ b/install-tools/metadata2hardware.py
@@ -1,7 +1,5 @@
 #!/usr/bin/python3
 
-from pprint import pprint
-import json
 import requests
 from glob import glob
 import re

--- a/install-tools/metadata2hardware.py
+++ b/install-tools/metadata2hardware.py
@@ -57,22 +57,18 @@ def mkInterfaces(blob):
       networking.interfaces.bond0 = {{
         useDHCP = true;
 
-        ip4 = [
-          {ip4s}
+        ip4 = [\n{ip4s}
         ];
 
-        ip6 = [
-          {ip6s}
+        ip6 = [\n{ip6s}
         ];
       }};
     """
 
-    ipPart = """
-          {{
+    ipPart = """          {{
             address = "{address}";
             prefixLength = {prefix};
-          }}
-    """
+          }}"""
 
     ip4s = []
     ip6s = []

--- a/install-tools/metadata2hardware.py
+++ b/install-tools/metadata2hardware.py
@@ -8,10 +8,11 @@ import re
 
 d = requests.get('https://metadata.packet.net/metadata').json()
 
+
 def mkRootPassword(path):
     cfg = """
       users.users.root.initialHashedPassword = "{}";
-    """;
+    """
 
     with open(path) as cmdline:
         line = cmdline.read()
@@ -21,6 +22,7 @@ def mkRootPassword(path):
             return cfg.format(pwhash)
     return ""
 
+
 def mkBonds(blob):
     cfg = """
       networking.bonds.bond0 = {{
@@ -29,33 +31,28 @@ def mkBonds(blob):
           {interfaces}
         ];
       }};
-    """;
+    """
     interfacePart = '"{}"'
 
-    modes = {
-        4: "802.3ad",
-        5: "balance-tlb"
-    }
+    modes = {4: "802.3ad", 5: "balance-tlb"}
     mode = modes[blob['network']['bonding']['mode']]
-    macToName = {open(f).read().strip(): f.split('/')[4]
-                     for f in glob('/sys/class/net/*/address')}
+    macToName = {open(f).read().strip(): f.split('/')[4] for f in glob('/sys/class/net/*/address')}
 
-    interfaces = [interfacePart.format(macToName[interface['mac']])
-                for interface
-                in blob['network']['interfaces']]
+    interfaces = [
+        interfacePart.format(macToName[interface['mac']])
+        for interface in blob['network']['interfaces']
+    ]
 
+    return cfg.format(mode=mode, interfaces=" ".join(interfaces))
 
-    return cfg.format(
-        mode=mode,
-        interfaces=" ".join(interfaces)
-    )
 
 def mkHostname(blob):
     cfg = """
       networking.hostName = "{}";
-    """;
+    """
 
     return cfg.format(blob['hostname'])
+
 
 def mkInterfaces(blob):
     cfg = """
@@ -70,49 +67,42 @@ def mkInterfaces(blob):
           {ip6s}
         ];
       }};
-    """;
+    """
 
     ipPart = """
           {{
             address = "{address}";
             prefixLength = {prefix};
           }}
-    """;
+    """
 
     ip4s = []
     ip6s = []
 
     for address in blob['network']['addresses']:
         if address['enabled']:
-            part = ipPart.format(
-                address=address['address'],
-                prefix=address['cidr']
-            )
+            part = ipPart.format(address=address['address'], prefix=address['cidr'])
             if address['address_family'] == 4:
                 ip4s.append(part)
             elif address['address_family'] == 6:
                 ip6s.append(part)
 
-    return cfg.format(
-        ip4s="\n".join(ip4s),
-        ip6s="\n".join(ip6s)
-    )
+    return cfg.format(ip4s="\n".join(ip4s), ip6s="\n".join(ip6s))
 
 
 def mkRootKeys(blob):
     cfg = """
       users.users.root.openssh.authorizedKeys.keys = [{keys}
       ];
-    """;
+    """
     keyPart = """
         "{}"
-    """;
+    """
 
     keyParts = [keyPart.format(key) for key in blob['ssh_keys']]
 
-    return cfg.format(
-        keys="\n".join(keyParts)
-    )
+    return cfg.format(keys="\n".join(keyParts))
+
 
 configParts = [
     mkHostname(d),
@@ -121,8 +111,4 @@ configParts = [
     mkRootKeys(d),
     mkRootPassword('/proc/cmdline')
 ]
-print("{",
-"".join(configParts)
-,
-"}"
-)
+print("{", "".join(configParts), "}")

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,10 @@
+[flake8]
+max-line-length = 100
+
+[pylama:pycodestyle]
+max_line_length = 100
+
+[yapf]
+based_on_style = chromium
+column_limit = 100
+indent_width = 4


### PR DESCRIPTION
These were done automatically by my vim setup using `yapf` and whatever python linters come in ale. The diff seemed pretty reasonable. I also tweaked the interfaces section so it doesn't have as much whitespace and matches the style in other parts of this file and other files.

This whole PR is just fluff leading up to the static networking configuration, if you'd rather not have this I'll drop it from the other branch/incoming-PR too.