### PR TITLE
Static networking

### DIFF
--- a/install-tools/metadata2hardware.py
+++ b/install-tools/metadata2hardware.py
@@ -47,6 +47,9 @@ def mkBonds(blob):
 def mkNetworking(blob):
     cfg = """
       networking.hostName = "{hostname}";
+
+      networking.dhcpcd.enable = false;
+
     """
 
     vals = {
@@ -59,8 +62,6 @@ def mkNetworking(blob):
 def mkInterfaces(blob):
     cfg = """
       networking.interfaces.bond0 = {{
-        useDHCP = true;
-
         ip4 = [\n{ip4s}
         ];
 

--- a/install-tools/metadata2hardware.py
+++ b/install-tools/metadata2hardware.py
@@ -44,7 +44,7 @@ def mkBonds(blob):
     return cfg.format(mode=mode, interfaces=" ".join(interfaces))
 
 
-def mkNetworking(blob):
+def mkNetworking(blob, path):
     cfg = """
       networking.hostName = "{hostname}";
 
@@ -59,6 +59,9 @@ def mkNetworking(blob):
         address = "{gateway6}";
         interface = "bond0";
       }};
+
+      networking.nameservers = [\n{nameservers}
+      ];
     """
 
     vals = {
@@ -73,6 +76,23 @@ def mkNetworking(blob):
             vals['gateway'] = address['gateway']
         elif address['address_family'] == 6:
             vals['gateway6'] = address['gateway']
+
+    nses = []
+    with open(path) as resolvconf:
+        for line in resolvconf:
+            x = re.search(r'^nameserver\s+([^\s]+)', line)
+            if x:
+                nses.append(x.group(1))
+
+    if not nses:
+        nses = [
+            '147.75.207.207',
+            '147.75.207.208',
+        ]
+
+    vals['nameservers'] = '\n'.join(['        "%s"' % ns for ns in nses])
+    for exp in ('hostname', 'gateway', 'gateway6', 'nameservers'):
+        assert exp in vals, 'missing configuration data: %s' % exp
 
     return cfg.format(**vals)
 
@@ -122,7 +142,7 @@ def mkRootKeys(blob):
 
 
 configParts = [
-    mkNetworking(d),
+    mkNetworking(d, '/etc/resolv.conf'),
     mkBonds(d),
     mkInterfaces(d),
     mkRootKeys(d),

--- a/install-tools/metadata2hardware.py
+++ b/install-tools/metadata2hardware.py
@@ -50,11 +50,29 @@ def mkNetworking(blob):
 
       networking.dhcpcd.enable = false;
 
+      networking.defaultGateway = {{
+        address =  "{gateway}";
+        interface = "bond0";
+      }};
+
+      networking.defaultGateway6 = {{
+        address = "{gateway6}";
+        interface = "bond0";
+      }};
     """
 
     vals = {
         'hostname': blob['hostname'],
     }
+
+    for address in blob['network']['addresses']:
+        if not (address['enabled'] and address['public']):
+            continue
+
+        if address['address_family'] == 4:
+            vals['gateway'] = address['gateway']
+        elif address['address_family'] == 6:
+            vals['gateway6'] = address['gateway']
 
     return cfg.format(**vals)
 

--- a/install-tools/metadata2hardware.py
+++ b/install-tools/metadata2hardware.py
@@ -44,12 +44,16 @@ def mkBonds(blob):
     return cfg.format(mode=mode, interfaces=" ".join(interfaces))
 
 
-def mkHostname(blob):
+def mkNetworking(blob):
     cfg = """
-      networking.hostName = "{}";
+      networking.hostName = "{hostname}";
     """
 
-    return cfg.format(blob['hostname'])
+    vals = {
+        'hostname': blob['hostname'],
+    }
+
+    return cfg.format(**vals)
 
 
 def mkInterfaces(blob):
@@ -99,7 +103,7 @@ def mkRootKeys(blob):
 
 
 configParts = [
-    mkHostname(d),
+    mkNetworking(d),
     mkBonds(d),
     mkInterfaces(d),
     mkRootKeys(d),


### PR DESCRIPTION
Fully configure networking statically. DHCP is not allowed for non custom_ipxe oses, except for a small window of time after provisioning completion. I'm not sure how exactly things actually worked as is, maybe dhcpcd cached some stuff and used it when it failed to get a lease?

I noticed this because I had dhcp requests routed to a nixos machine I've got, the dhcp requests of said nix server were also being routed to itself and when no dhcp server responded (or NACKd?) my network config was affected. I had no default gateways and no dns servers configured.

This PR brings nixos to work in the same fashion as all of the other packet supported OSes.