### PR TITLE
Load ipmi_watchdog kernel module

### DIFF
--- a/instances/standard.nix
+++ b/instances/standard.nix
@@ -1,4 +1,4 @@
 {
-  boot.kernelModules = [ "dm_multipath" "dm_round_robin" ];
+  boot.kernelModules = [ "dm_multipath" "dm_round_robin" "ipmi_watchdog" ];
   services.openssh.enable = true;
 }


### PR DESCRIPTION
All Packet servers should have IPMI, which can be used to setup a watchdog. Loading this module causes /dev/watchdog device to appear, and that can be then used by systemd (see https://www.freedesktop.org/software/systemd/man/systemd-system.conf.html, `RuntimeWatchdogSec` in particular).