### PR TITLE
tools.sh: apply configuration twice to pickup nix.* values

### DIFF
--- a/install-tools/bin/tools.sh
+++ b/install-tools/bin/tools.sh
@@ -89,7 +89,8 @@ do_install() {
     apply_user_data
     if ! nixos-install < /dev/null; then
         delete_user_data
-    fi
+    fin
+    nixos-install < /dev/null # apply second time to rebuild with new effective nix.* values
 
     notify.py installed
     touch /mnt/etc/.packet-phone-home


### PR DESCRIPTION
Fixes #14.

This will allow the user to supply a user data that set custom nix options (like a NIX_PATH to a specific nixpkgs and setting `nix.buildCores = 0` on a beefy Packet EPYC machine).

It feels hacky, but also not that bad and solves a need without any heavy lifting. Please note, I don't have PXE infra setup to test this, and I'm making assumptions about `nixos-install` operating similarly to `nixos-rebuild switch`... hopefully you can validate @grahamc.