### PR TITLE
Add x2.xlarge.x86

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -442,4 +442,32 @@ in rec {
       mount -L nixos /mnt
     '';
   };
+
+  x2-xlarge-x86 = mkPXEInstaller {
+    name = "x2.xlarge.x86";
+    system = "x86_64-linux";
+    img = "bzImage";
+    kexec = true;
+
+    configFiles = [
+      ./instances/standard.nix
+      ./instances/x2.xlarge.x86/hardware.nix
+    ];
+
+    runTimeConfigFiles = [
+      ./instances/x2.xlarge.x86/installed.nix
+    ];
+
+    partition = partitionLinuxWithBootSwap "/dev/sda";
+
+    format = ''
+      mkswap -L swap /dev/sda2
+      mkfs.ext4 -L nixos /dev/sda3
+    '';
+
+    mount = ''
+      swapon -L swap
+      mount -L nixos /mnt
+    '';
+  };
 }

--- a/instances/x2.xlarge.x86/hardware.nix
+++ b/instances/x2.xlarge.x86/hardware.nix
@@ -21,4 +21,6 @@
   hardware.enableAllFirmware = true;
 
   nix.maxJobs = 56;
+
+  services.xserver.videoDrivers = [ "nvidia" ];
 }

--- a/instances/x2.xlarge.x86/hardware.nix
+++ b/instances/x2.xlarge.x86/hardware.nix
@@ -1,0 +1,24 @@
+{ config, lib, pkgs, ... }:
+{
+  nixpkgs.config.allowUnfree = true;
+  nixpkgs.config.packageOverrides = pkgs:
+      { linux_4_14 = pkgs.linux_4_14.override {
+          extraConfig =
+            ''
+              MLX5_CORE_EN y
+            '';
+        };
+      };
+
+  boot.kernelPackages = pkgs.linuxPackages_4_14;
+  boot.initrd.availableKernelModules = [
+    "xhci_pci" "ahci" "usbhid" "mpt3sas" "nvme" "sd_mod"
+  ];
+  boot.kernelModules = [ "kvm-intel" ];
+  boot.kernelParams =  [ "console=ttyS1,115200n8" ];
+  boot.extraModulePackages = [ ];
+
+  hardware.enableAllFirmware = true;
+
+  nix.maxJobs = 56;
+}

--- a/instances/x2.xlarge.x86/installed.nix
+++ b/instances/x2.xlarge.x86/installed.nix
@@ -1,0 +1,21 @@
+{
+  boot.loader.grub.devices = [ "/dev/sda" ];
+  boot.loader.grub.extraConfig = ''
+    serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+    terminal_output serial console
+    terminal_input serial console
+  '';
+
+  fileSystems = {
+    "/" = {
+      label = "nixos";
+      fsType = "ext4";
+    };
+  };
+
+  swapDevices = [
+    {
+      label = "swap";
+    }
+  ];
+}


### PR DESCRIPTION
I recently started playing around with the `x2.xlarge.x86` instances of Packet and figured there was no NixOS support for them yet.

This PR adds the basic support for the machine and in an additional commit adds "full" hardware support by including the NVIDIA driver options. MOst of this is a 1:1 copy of other hardware that already existed in the repo.

It might turn out to be not desirable to distribute pre-compiled NVIDIA drivers due to whatever legal issues there might be. I am not a lawyer so I can not really judge the situation.

