### PR TITLE
18.09 redux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ result
 result-*
 .buildkite
 pxe-known-host
+result.drv

--- a/all.nix
+++ b/all.nix
@@ -27,7 +27,7 @@ let
     mv "./nixos-netboot-images-$now.tar.bz2" $out/
 '';
 in pkgs.runCommand "indexed-pxe-images" {} ''
-  cp -r ${if false then all else allWithTarball} $out
+  cp -r ${if true then all else allWithTarball} $out
 chmod u+w $out
 
 cd $out

--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,7 @@ buildHost=root@$PXE_BUILD_HOST
 
 set -x
 
-drv=$(nix-instantiate ./all.nix --show-trace)
+drv=$(realpath $(nix-instantiate ./all.nix --show-trace --add-root ./result.drv --indirect))
 
 export NIX_SSHOPTS="-o UserKnownHostsFile=./pxe-known-host"
 nix-copy-closure --to "$buildHost" "$drv"

--- a/expect-tests/console.sh
+++ b/expect-tests/console.sh
@@ -8,7 +8,10 @@ REGION=$2
 while true; do
     echo "reconnecting" >&2
 
-    ssh "${UUID}@sos.${REGION}.packet.net"
+    ssh \
+        -o StrictHostKeyChecking=no \
+        -o UserKnownHostsFile=/dev/null \
+        "${UUID}@sos.${REGION}.packet.net"
     printf "\n\n\n\n\n"
 
     echo "disconnected"

--- a/expect-tests/create.sh
+++ b/expect-tests/create.sh
@@ -35,7 +35,7 @@ function make_server() {
 EOF
         )
 
-    echo "Creating server with: ${json}"
+    echo "Creating server with: ${json}" >&2
 
     curl --data "$json" \
          --header 'Accept: application/json' \

--- a/expect-tests/create.sh
+++ b/expect-tests/create.sh
@@ -71,11 +71,9 @@ function delete() {
 name="$1"
 
 if [ "$name" == "c1.large.arm.xda" ]; then
-   pxe_url="$IPXE_ROOT/c1.large.arm/netboot.ipxe"
-#elif [ "$name" == "c2.medium.x86" ]; then
-#   pxe_url="http://147.75.197.111/c2med/netboot.ipxe"
+   pxe_url="$PXE_ROOT/c1.large.arm/netboot.ipxe"
 else
-   pxe_url="$IPXE_ROOT/$name/netboot.ipxe"
+   pxe_url="$PXE_ROOT/$name/netboot.ipxe"
 fi
 
 url=$(make_server "$name" "$pxe_url")

--- a/expect-tests/testall.sh
+++ b/expect-tests/testall.sh
@@ -20,6 +20,7 @@ check() {
 }
 
 check c1.large.arm
+check c1.large.arm.xda
 check c1.small.x86
 check c1.xlarge.x86
 check c2.medium.x86

--- a/expect-tests/testall.sh
+++ b/expect-tests/testall.sh
@@ -19,15 +19,17 @@ check() {
     )&
 }
 
-check c1.small.x86
 check c1.large.arm
+check c1.small.x86
 check c1.xlarge.x86
 check c2.medium.x86
-check t1.small.x86
-check s1.large.x86
+check g2.large.x86
 check m1.xlarge.x86
 check m2.xlarge.x86
+check s1.large.x86
+check t1.small.x86
 check x1.small.x86
+check x2.xlarge.x86
 
 wait
 for i in $(seq 1 "$started"); do

--- a/instances/c1.large.arm/hardware.nix
+++ b/instances/c1.large.arm/hardware.nix
@@ -17,8 +17,6 @@
     kernelParams = [
       "cma=0M" "biosdevname=0" "net.ifnames=0" "console=ttyAMA0"
     ];
-
-    kernelPackages = pkgs.linuxPackages_4_14;
   };
 
   nix = {

--- a/instances/c1.xlarge.x86/hardware.nix
+++ b/instances/c1.xlarge.x86/hardware.nix
@@ -3,18 +3,9 @@
   nixpkgs = {
     config = {
       allowUnfree = true;
-      packageOverrides = pkgs: {
-        linux_4_14 = pkgs.linux_4_14.override {
-        extraConfig =
-          ''
-            MLX5_CORE_EN y
-          '';
-        };
-      };
     };
   };
 
-  boot.kernelPackages = pkgs.linuxPackages_4_14;
   boot.initrd.availableKernelModules = [
     "xhci_pci" "ehci_pci" "ahci" "usbhid" "sd_mod" "megaraid_sas"
     "nvme"

--- a/instances/c2.medium.x86/hardware.nix
+++ b/instances/c2.medium.x86/hardware.nix
@@ -3,18 +3,9 @@
   nixpkgs = {
     config = {
       allowUnfree = true;
-      packageOverrides = pkgs:
-      { linux_4_14 = pkgs.linux_4_14.override {
-          extraConfig =
-            ''
-              MLX5_CORE_EN y
-            '';
-        };
-      };
     };
   };
 
-  boot.kernelPackages = pkgs.linuxPackages_4_14;
   boot.loader.grub = {
     version = 2;
     efiSupport = true;

--- a/instances/g2.large.x86/hardware.nix
+++ b/instances/g2.large.x86/hardware.nix
@@ -1,16 +1,6 @@
 { config, lib, pkgs, ... }:
 {
   nixpkgs.config.allowUnfree = true;
-  nixpkgs.config.packageOverrides = pkgs:
-      { linux_4_14 = pkgs.linux_4_14.override {
-          extraConfig =
-            ''
-              MLX5_CORE_EN y
-            '';
-        };
-      };
-
-  boot.kernelPackages = pkgs.linuxPackages_4_14;
   boot.initrd.availableKernelModules = [
     "xhci_pci" "ahci" "usbhid" "mpt3sas" "nvme" "sd_mod"
   ];

--- a/instances/m1.xlarge.x86/hardware.nix
+++ b/instances/m1.xlarge.x86/hardware.nix
@@ -1,20 +1,11 @@
 { pkgs, ... }:
 {
   nixpkgs.config.allowUnfree = true;
-  nixpkgs.config.packageOverrides = pkgs: {
-    linux_4_14 = pkgs.linux_4_14.override {
-      extraConfig =
-        ''
-          MLX5_CORE_EN y
-        '';
-    };
-  };
 
   boot.initrd.availableKernelModules = [
     "xhci_pci" "ehci_pci" "ahci" "megaraid_sas" "sd_mod"
   ];
 
-  boot.kernelPackages = pkgs.linuxPackages_4_14;
   boot.kernelModules = [ "kvm-intel" ];
   boot.kernelParams =  [ "console=ttyS1,115200n8" ];
   boot.extraModulePackages = [ ];

--- a/instances/m2.xlarge.x86/hardware.nix
+++ b/instances/m2.xlarge.x86/hardware.nix
@@ -1,16 +1,7 @@
 { config, lib, pkgs, ... }:
 {
   nixpkgs.config.allowUnfree = true;
-  nixpkgs.config.packageOverrides = pkgs:
-      { linux_4_14 = pkgs.linux_4_14.override {
-          extraConfig =
-            ''
-              MLX5_CORE_EN y
-            '';
-        };
-      };
 
-  boot.kernelPackages = pkgs.linuxPackages_4_14;
   boot.initrd.availableKernelModules = [
     "ahci" "xhci_pci" "mpt3sas" "nvme" "sd_mod"
   ];

--- a/instances/s1.large.x86/hardware.nix
+++ b/instances/s1.large.x86/hardware.nix
@@ -3,18 +3,8 @@
   nixpkgs = {
     config = {
       allowUnfree = true;
-      packageOverrides = pkgs:
-      { linux_4_14 = pkgs.linux_4_14.override {
-          extraConfig =
-            ''
-              MLX5_CORE_EN y
-            '';
-        };
-      };
     };
   };
-
-  boot.kernelPackages = pkgs.linuxPackages_4_14;
 
   boot.initrd.availableKernelModules = [
     "ahci" "xhci_pci" "ehci_pci" "mpt3sas" "usbhid" "sd_mod"

--- a/instances/x2.xlarge.x86/hardware.nix
+++ b/instances/x2.xlarge.x86/hardware.nix
@@ -1,16 +1,6 @@
 { config, lib, pkgs, ... }:
 {
   nixpkgs.config.allowUnfree = true;
-  nixpkgs.config.packageOverrides = pkgs:
-      { linux_4_14 = pkgs.linux_4_14.override {
-          extraConfig =
-            ''
-              MLX5_CORE_EN y
-            '';
-        };
-      };
-
-  boot.kernelPackages = pkgs.linuxPackages_4_14;
   boot.initrd.availableKernelModules = [
     "xhci_pci" "ahci" "usbhid" "mpt3sas" "nvme" "sd_mod"
   ];

--- a/nix/config.nix
+++ b/nix/config.nix
@@ -1,0 +1,25 @@
+let
+  pkgs = import <nixpkgs> {};
+  pin_file = "${toString ./.}/nixpkgs.json";
+
+  url = "https://github.com/nixos/nixpkgs-channels.git";
+in rec {
+  branch = "nixos-18.09";
+
+  pinned = let
+      src = builtins.fromJSON (builtins.readFile ./nixpkgs.json);
+    in {
+      inherit (src) url rev;
+      ref = "${branch}";
+    };
+
+  update = pkgs.writeScript "update.sh" ''
+    #!${pkgs.bash}/bin/bash
+
+    set -euxo pipefail
+
+    ${pkgs.nix-prefetch-git}/bin/nix-prefetch-git \
+      "${url}" \
+      --rev "refs/heads/${branch}" > "${pin_file}"
+  '';
+}

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,5 +1,4 @@
 let
-  rev = "49a6964a4250d98644da61f24dcc11ee0b28c4f9";
-in import (builtins.fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
-})
+  config = import ./config.nix;
+  nixpkgs = builtins.fetchGit config.pinned;
+in import nixpkgs

--- a/nix/nixpkgs.json
+++ b/nix/nixpkgs.json
@@ -1,0 +1,7 @@
+{
+  "url": "https://github.com/nixos/nixpkgs-channels.git",
+  "rev": "97e0d53d669cd07f0750a42fd535524b3cdd46d1",
+  "date": "2019-01-15T00:11:44+01:00",
+  "sha256": "111xa7qn9142dar29cil4br2mvn8f1rbiy310lkhwl73126fq8dw",
+  "fetchSubmodules": false
+}

--- a/nix/update-nixpkgs.sh
+++ b/nix/update-nixpkgs.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+
+set -euxo pipefail
+
+updateScript=$(nix-build --no-out-link ./nix/config.nix -A update)
+$updateScript


### PR DESCRIPTION
503 = no capacity

```
$ tail -c300 ./testlog.*
==> ./testlog.c1.large.arm <==
100   575    0     0  100   575      0    368  0:00:01  0:00:01 --:--:--   368
curl: (22) The requested URL returned error: 503 
c1.large.arm start: Fri Jan 18 18:33:36 EST 2019
c1.large.arm end: Fri Jan 18 18:33:38 EST 2019
c1.large.arm Exit code: 22

==> ./testlog.c1.small.x86 <==
  0     0    0     0    0     0      0      0 --:--:--  0:00:02 --:--:--     0
c1.small.x86 start: Fri Jan 18 18:33:37 EST 2019
c1.small.x86 end: Fri Jan 18 18:52:05 EST 2019
c1.small.x86 Exit code: 0

==> ./testlog.c1.xlarge.x86 <==
100   578    0     0  100   578      0    303  0:00:01  0:00:01 --:--:--   303
curl: (22) The requested URL returned error: 503 
c1.xlarge.x86 start: Fri Jan 18 18:33:38 EST 2019
c1.xlarge.x86 end: Fri Jan 18 18:33:40 EST 2019
c1.xlarge.x86 Exit code: 22

==> ./testlog.c2.medium.x86 <==
  0     0    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0
c2.medium.x86 start: Fri Jan 18 18:33:39 EST 2019
c2.medium.x86 end: Fri Jan 18 18:49:18 EST 2019
c2.medium.x86 Exit code: 0

==> ./testlog.g2.large.x86 <==
100   575    0     0  100   575      0    413  0:00:01  0:00:01 --:--:--   413
curl: (22) The requested URL returned error: 422 
g2.large.x86 start: Fri Jan 18 18:33:40 EST 2019
g2.large.x86 end: Fri Jan 18 18:33:42 EST 2019
g2.large.x86 Exit code: 22

==> ./testlog.m1.xlarge.x86 <==
008\u0008\u0008\u001b[25;14H\u0008\u0008\u0008\u0008\u0008\u0008\u0008\u0008\u001b[25;14H\u0008\u0008\u0008\u0008\u0008\u0008\u0008\u0008\u001b[25;14H\u0008\u0008\u0008\u0008\u0008\u0008\u0008\u0008\u001b[25;14H" (spawn_id exp4) match glob pattern "Welcome to NixOS"? no
"test-instance login:"? no

==> ./testlog.m2.xlarge.x86 <==
  0     0    0     0    0     0      0      0 --:--:--  0:00:02 --:--:--     0
m2.xlarge.x86 start: Fri Jan 18 18:33:42 EST 2019
m2.xlarge.x86 end: Fri Jan 18 18:51:12 EST 2019
m2.xlarge.x86 Exit code: 0

==> ./testlog.s1.large.x86 <==
  0     0    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0
s1.large.x86 start: Fri Jan 18 18:33:43 EST 2019
s1.large.x86 end: Fri Jan 18 18:46:24 EST 2019
s1.large.x86 Exit code: 0

==> ./testlog.t1.small.x86 <==
  0     0    0     0    0     0      0      0 --:--:--  0:00:02 --:--:--     0
t1.small.x86 start: Fri Jan 18 18:33:44 EST 2019
t1.small.x86 end: Fri Jan 18 18:51:22 EST 2019
t1.small.x86 Exit code: 0

==> ./testlog.x1.small.x86 <==
100   575    0     0  100   575      0    550  0:00:01  0:00:01 --:--:--   550
curl: (22) The requested URL returned error: 500 
x1.small.x86 start: Fri Jan 18 18:33:45 EST 2019
x1.small.x86 end: Fri Jan 18 18:33:46 EST 2019
x1.small.x86 Exit code: 22

==> ./testlog.x2.xlarge.x86 <==
  0     0    0     0    0     0      0      0 --:--:--  0:00:02 --:--:--     0
x2.xlarge.x86 start: Fri Jan 18 18:33:46 EST 2019
x2.xlarge.x86 end: Fri Jan 18 18:51:29 EST 2019
x2.xlarge.x86 Exit code: 0
```
