### PR TITLE
add support for g2.large.x86

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -470,4 +470,33 @@ in rec {
       mount -L nixos /mnt
     '';
   };
+
+  g2-large-x86 = mkPXEInstaller {
+    name = "g2.large.x86";
+    system = "x86_64-linux";
+    img = "bzImage";
+    kexec = true;
+
+    configFiles = [
+      ./instances/standard.nix
+      ./instances/g2.large.x86/hardware.nix
+    ];
+
+    runTimeConfigFiles = [
+      ./instances/g2.large.x86/installed.nix
+    ];
+
+    partition = partitionLinuxWithBootSwap "/dev/sda";
+
+    format = ''
+      mkswap -L swap /dev/sda2
+      mkfs.ext4 -L nixos /dev/sda3
+    '';
+
+    mount = ''
+      swapon -L swap
+      mount -L nixos /mnt
+    '';
+  };
+
 }

--- a/instances/g2.large.x86/hardware.nix
+++ b/instances/g2.large.x86/hardware.nix
@@ -1,0 +1,26 @@
+{ config, lib, pkgs, ... }:
+{
+  nixpkgs.config.allowUnfree = true;
+  nixpkgs.config.packageOverrides = pkgs:
+      { linux_4_14 = pkgs.linux_4_14.override {
+          extraConfig =
+            ''
+              MLX5_CORE_EN y
+            '';
+        };
+      };
+
+  boot.kernelPackages = pkgs.linuxPackages_4_14;
+  boot.initrd.availableKernelModules = [
+    "xhci_pci" "ahci" "usbhid" "mpt3sas" "nvme" "sd_mod"
+  ];
+  boot.kernelModules = [ "kvm-intel" ];
+  boot.kernelParams =  [ "console=ttyS1,115200n8" ];
+  boot.extraModulePackages = [ ];
+
+  hardware.enableAllFirmware = true;
+
+  nix.maxJobs = 48;
+
+  services.xserver.videoDrivers = [ "nvidia" ];
+}

--- a/instances/g2.large.x86/installed.nix
+++ b/instances/g2.large.x86/installed.nix
@@ -1,0 +1,21 @@
+{
+  boot.loader.grub.devices = [ "/dev/sda" ];
+  boot.loader.grub.extraConfig = ''
+    serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+    terminal_output serial console
+    terminal_input serial console
+  '';
+
+  fileSystems = {
+    "/" = {
+      label = "nixos";
+      fsType = "ext4";
+    };
+  };
+
+  swapDevices = [
+    {
+      label = "swap";
+    }
+  ];
+}


### PR DESCRIPTION
This is almost a 1:1 copy of the x2.xlarge.x86 expression. The `maxJobs`
attribute has been adjusted to fit the hardware.

The hardware is mostly identical to the x2.xlarge.x86 instance for our
purposes. It comes with one SSD that we use for the OS (as long as it
comes first aka is sda). The larger disks are not touched during
the installation - as usual.